### PR TITLE
fix: resolve GitHub Actions compatibility and dependency issues

### DIFF
--- a/.github/workflows/runlintic-ci.yml
+++ b/.github/workflows/runlintic-ci.yml
@@ -16,10 +16,10 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       
     - name: Setup Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v5
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
@@ -43,10 +43,10 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v5
       with:
         node-version: '22.x'
         cache: 'npm'
@@ -66,13 +66,13 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         # Fetch full history for release-it
         fetch-depth: 0
         
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v5
       with:
         node-version: '22.x'
         cache: 'npm'

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -15,13 +15,15 @@ jobs:
     permissions:
       security-events: write
       contents: read
+      issues: write
+      pull-requests: write
       
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '22'
           cache: 'npm'
@@ -78,7 +80,7 @@ jobs:
           
       - name: Comment PR with security status
         if: github.event_name == 'pull_request'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const fs = require('fs');
@@ -120,7 +122,7 @@ jobs:
       
     steps:
       - name: Checkout repository  
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         
       - name: Dependency Review
         uses: actions/dependency-review-action@v4

--- a/knip.json
+++ b/knip.json
@@ -29,7 +29,11 @@
   "ignoreDependencies": [
     "@types/*",
     "conventional-changelog-conventionalcommits",
-    "eslint-plugin-turbo"
+    "eslint-plugin-turbo",
+    "lilconfig",
+    "picocolors",
+    "prompts",
+    "@commitlint/config-conventional"
   ],
   "includeEntryExports": false
 }


### PR DESCRIPTION
## Summary
- Update GitHub Actions to latest versions (checkout@v5, setup-node@v5, github-script@v8)
- Add missing permissions to security workflow to prevent 403 errors
- Configure knip to properly ignore security override packages and commitlint dependency

## Test plan
- [x] Health check passes locally
- [x] All lint/typecheck/maintenance tasks succeed
- [x] Security audit shows no vulnerabilities
- [x] Knip no longer reports false positive unused dependencies

This PR resolves the issues preventing Dependabot PRs #22, #23, and #24 from passing their quality checks.

🤖 Generated with [Claude Code](https://claude.ai/code)