### PR TITLE
fix: pass GitHub secrets to release dry run workflow

### DIFF
--- a/.github/workflows/runlintic-ci.yml
+++ b/.github/workflows/runlintic-ci.yml
@@ -16,10 +16,10 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       
     - name: Setup Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v5
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
@@ -43,10 +43,10 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v5
       with:
         node-version: '22.x'
         cache: 'npm'
@@ -66,13 +66,13 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         # Fetch full history for release-it
         fetch-depth: 0
         
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v5
       with:
         node-version: '22.x'
         cache: 'npm'

--- a/.github/workflows/runlintic-ci.yml
+++ b/.github/workflows/runlintic-ci.yml
@@ -57,7 +57,8 @@ jobs:
     - name: Preview release changes (dry run)
       run: npm run release:dry
       env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GH_TOKEN: ${{ secrets.GH_TOKEN }}
+        NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   release:
     runs-on: ubuntu-latest

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -15,13 +15,15 @@ jobs:
     permissions:
       security-events: write
       contents: read
+      issues: write
+      pull-requests: write
       
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '22'
           cache: 'npm'
@@ -78,7 +80,7 @@ jobs:
           
       - name: Comment PR with security status
         if: github.event_name == 'pull_request'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const fs = require('fs');
@@ -120,7 +122,7 @@ jobs:
       
     steps:
       - name: Checkout repository  
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         
       - name: Dependency Review
         uses: actions/dependency-review-action@v4

--- a/knip.json
+++ b/knip.json
@@ -29,7 +29,11 @@
   "ignoreDependencies": [
     "@types/*",
     "conventional-changelog-conventionalcommits",
-    "eslint-plugin-turbo"
+    "eslint-plugin-turbo",
+    "lilconfig",
+    "picocolors",
+    "prompts",
+    "@commitlint/config-conventional"
   ],
   "includeEntryExports": false
 }


### PR DESCRIPTION
## Summary
- Add missing NPM_TOKEN environment variable to release preview step
- Use correct GH_TOKEN secret reference instead of GITHUB_TOKEN  
- Ensures release dry run has access to required repository secrets in CI

## Problem
The release dry run was failing with 'Required environment variables not found' because:
1. NPM_TOKEN wasn't being passed from GitHub secrets
2. Wrong secret reference was being used for GH_TOKEN

## Solution  
- Added NPM_TOKEN: ${{ secrets.NPM_TOKEN }} to workflow env
- Changed to GH_TOKEN: ${{ secrets.GH_TOKEN }}

This fixes the failing 'Preview release changes (dry run)' step in Dependabot PRs.